### PR TITLE
feat: Clean up enrollment ID; Rename to Assignment

### DIFF
--- a/packages/browser-demo/src/App.js
+++ b/packages/browser-demo/src/App.js
@@ -7,7 +7,7 @@ import { useSkylab, SkylabProvider } from './skylab';
 Skylab.init('client-IAxMYws9vVQESrrK88aTcToyqMxiiJoR', {
   initialFlags: { 'js-browser-demo': 'initial' },
   preferInitialFlags: true,
-  debugEnrollmentRequests: true,
+  debugAssignmentRequests: true,
   debug: true,
 });
 

--- a/packages/browser/src/config.ts
+++ b/packages/browser/src/config.ts
@@ -10,9 +10,9 @@ export interface SkylabConfig {
   debug?: boolean;
 
   /**
-   * Set to true to view enrollment requests in the UI debugger
+   * Set to true to view assignment requests in the UI debugger
    */
-  debugEnrollmentRequests?: boolean;
+  debugAssignmentRequests?: boolean;
 
   /**
    * The default fallback variant for all {@link SkylabClient.getVariant} calls.
@@ -58,7 +58,7 @@ export interface SkylabConfig {
  | **Option**       | **Default**                       |
  |------------------|-----------------------------------|
  | **debug**        | false                             |
- | **debugEnrollmentRequests** | false                  |
+ | **debugAssignmentRequests** | false                  |
  | **fallbackVariant**         | ""                     |
  | **instanceName** | `"$default_instance"`             |
  | **isServerSide**            | false                  |
@@ -71,7 +71,7 @@ export interface SkylabConfig {
  */
 export const Defaults: SkylabConfig = {
   debug: false,
-  debugEnrollmentRequests: false,
+  debugAssignmentRequests: false,
   fallbackVariant: '',
   instanceName: '$default_instance',
   isServerSide: false,


### PR DESCRIPTION
Remove the enrollment ID from the code base since it is no longer being used.

Talked with curtis about "enrollment" and that we would like to call it "assignment" instead.

This is a breaking change due to changing the name of the config variable.