### PR TITLE
feat: Implement fetch timeout and retries in SkylabClient

### DIFF
--- a/packages/browser-demo/src/App.js
+++ b/packages/browser-demo/src/App.js
@@ -43,7 +43,7 @@ const Feature = (props) => {
 
 export default function App() {
   return (
-    <SkylabProvider user={{ user_id: 'user_id', device_family: 'device_family' }}>
+    <SkylabProvider skylabUser={{ user_id: 'user_id', device_family: 'device_family' }}>
       <div className="container">
         <main className="main">
           <h1 className="title">Browser demo for Skylab</h1>

--- a/packages/browser/src/config.ts
+++ b/packages/browser/src/config.ts
@@ -57,22 +57,31 @@ export interface SkylabConfig {
   fetchTimeoutMillis?: number;
 
   /**
-   * Whether or not to retry fetching variants if the initial request fails. Retries will be scheduled at an
-   * interval defined by `fetchRetryIntervalMillis`, with a timeout defined by `fetchRetryTimeoutMillis`.
+   * The number of retries to attempt before failing
    */
-  fetchRetry?: boolean;
+  fetchRetries?: number;
 
   /**
-   * The request timeout for retrying fetch requests. Should be less than or equal to the
-   * `fetchRetryIntervalMillis` config.
+   * Retry backoff minimum (starting backoff delay) in milliseconds. The minimum backoff is scaled by
+   * `fetchRetryBackoffScalar` after each retry failure.
+   */
+  fetchRetryBackoffMinMillis: number;
+
+  /**
+   * Retry backoff maximum in milliseconds. If the scaled backoff is greater than the max, the max is
+   * used for all subsequent retries.
+   */
+  fetchRetryBackoffMaxMillis: number;
+
+  /**
+   * Scales the minimum backoff exponentially.
+   */
+  fetchRetryBackoffScalar: number;
+
+  /**
+   * The request timeout for retrying fetch requests.
    */
   fetchRetryTimeoutMillis?: number;
-
-  /**
-   * The interval at which to retry if fetching variants fails. Should be greater than or equal to the
-   * `fetchRetryTimeoutMillis` config.
-   */
-  fetchRetryIntervalMillis?: number;
 }
 
 /**
@@ -88,10 +97,12 @@ export interface SkylabConfig {
  | **preferInitialFlags**      | false                  |
  | **serverUrl**    | `"https://api.lab.amplitude.com"` |
  | **storageKey**    | `"amp-sl-meta"` |
- | **fetchTimeoutMillis**        | `5000`                |
- | **fetchRetry**                | `true`               |
- | **fetchRetryTimeoutMillis**   | `10000`              |
- | **fetchRetryIntervalMillis**  | `10000`              |
+ | **fetchTimeoutMillis**    | `10000` |
+ | **fetchRetries**    | `8` |
+ | **fetchRetryBackoffMinMillis**    | `500` |
+ | **fetchRetryBackoffMaxMillis**    | `10000` |
+ | **fetchRetryBackoffScalar**    | `1.5` |
+ | **fetchRetryTimeoutMillis**    | `10000` |
 
  *
  * @category Configuration
@@ -106,7 +117,9 @@ export const Defaults: SkylabConfig = {
   serverUrl: 'https://api.lab.amplitude.com',
   storageKey: 'amp-sl-meta',
   fetchTimeoutMillis: 10000,
-  fetchRetry: true,
+  fetchRetries: 8,
+  fetchRetryBackoffMinMillis: 500,
+  fetchRetryBackoffMaxMillis: 10000,
+  fetchRetryBackoffScalar: 1.5,
   fetchRetryTimeoutMillis: 10000,
-  fetchRetryIntervalMillis: 10000,
 };

--- a/packages/browser/src/config.ts
+++ b/packages/browser/src/config.ts
@@ -63,7 +63,7 @@ export interface SkylabConfig {
   fetchRetry: boolean;
 
   /**
-   * The request timeout for retrying fetch requests. Should be less than or eqial to the
+   * The request timeout for retrying fetch requests. Should be less than or equal to the
    * `fetchRetryIntervalMillis` config.
    */
   fetchRetryTimeoutMillis: number;

--- a/packages/browser/src/config.ts
+++ b/packages/browser/src/config.ts
@@ -105,7 +105,7 @@ export const Defaults: SkylabConfig = {
   preferInitialFlags: false,
   serverUrl: 'https://api.lab.amplitude.com',
   storageKey: 'amp-sl-meta',
-  fetchTimeoutMillis: 1,
+  fetchTimeoutMillis: 500,
   fetchRetry: true,
   fetchRetryTimeoutMillis: 10000,
   fetchRetryIntervalMillis: 10000,

--- a/packages/browser/src/config.ts
+++ b/packages/browser/src/config.ts
@@ -54,25 +54,25 @@ export interface SkylabConfig {
   /**
    * The request timeout, in milliseconds, used when fetching variants triggered by calling start() or setUser().
    */
-  fetchTimeoutMillis: number;
+  fetchTimeoutMillis?: number;
 
   /**
    * Whether or not to retry fetching variants if the initial request fails. Retries will be scheduled at an
    * interval defined by `fetchRetryIntervalMillis`, with a timeout defined by `fetchRetryTimeoutMillis`.
    */
-  fetchRetry: boolean;
+  fetchRetry?: boolean;
 
   /**
    * The request timeout for retrying fetch requests. Should be less than or equal to the
    * `fetchRetryIntervalMillis` config.
    */
-  fetchRetryTimeoutMillis: number;
+  fetchRetryTimeoutMillis?: number;
 
   /**
    * The interval at which to retry if fetching variants fails. Should be greater than or equal to the
    * `fetchRetryTimeoutMillis` config.
    */
-  fetchRetryIntervalMillis: number;
+  fetchRetryIntervalMillis?: number;
 }
 
 /**
@@ -105,7 +105,7 @@ export const Defaults: SkylabConfig = {
   preferInitialFlags: false,
   serverUrl: 'https://api.lab.amplitude.com',
   storageKey: 'amp-sl-meta',
-  fetchTimeoutMillis: 500,
+  fetchTimeoutMillis: 1,
   fetchRetry: true,
   fetchRetryTimeoutMillis: 10000,
   fetchRetryIntervalMillis: 10000,

--- a/packages/browser/src/config.ts
+++ b/packages/browser/src/config.ts
@@ -105,7 +105,7 @@ export const Defaults: SkylabConfig = {
   preferInitialFlags: false,
   serverUrl: 'https://api.lab.amplitude.com',
   storageKey: 'amp-sl-meta',
-  fetchTimeoutMillis: 500,
+  fetchTimeoutMillis: 5000,
   fetchRetry: true,
   fetchRetryTimeoutMillis: 10000,
   fetchRetryIntervalMillis: 10000,

--- a/packages/browser/src/config.ts
+++ b/packages/browser/src/config.ts
@@ -57,10 +57,16 @@ export interface SkylabConfig {
   fetchTimeoutMillis: number;
 
   /**
-   * The number of retries to attempt if fetching variants triggered by start() or setUser() fails.
-   * // TODO: Implment background retries.
+   * Whether or not to retry fetching variants if the initial request fails. Retries will be scheduled at an
+   * interval defined by `fetchRetryIntervalMillis`.
    */
-  fetchRetries: number;
+  fetchRetry: boolean;
+
+  /**
+   * The interval at which to retry if the intitial variant fetch fails. This should be greater than
+   * `fetchTimeoutMillis`.
+   */
+  fetchRetryIntervalMillis: number;
 }
 
 /**
@@ -76,6 +82,9 @@ export interface SkylabConfig {
  | **preferInitialFlags**      | false                  |
  | **serverUrl**    | `"https://api.lab.amplitude.com"` |
  | **storageKey**    | `"amp-sl-meta"` |
+ | **fetchTimeoutMillis**        | `500`                |
+ | **fetchRetry**                | `true`               |
+ | **fetchRetryIntervalMillis**  | `5000`               |
 
  *
  * @category Configuration
@@ -89,6 +98,7 @@ export const Defaults: SkylabConfig = {
   preferInitialFlags: false,
   serverUrl: 'https://api.lab.amplitude.com',
   storageKey: 'amp-sl-meta',
-  fetchTimeoutMillis: 1000,
-  fetchRetries: 5,
+  fetchTimeoutMillis: 500,
+  fetchRetry: true,
+  fetchRetryIntervalMillis: 5000,
 };

--- a/packages/browser/src/config.ts
+++ b/packages/browser/src/config.ts
@@ -50,6 +50,17 @@ export interface SkylabConfig {
    * The local storage key to use for storing metadata
    */
   storageKey?: 'amp-sl-meta';
+
+  /**
+   * The request timeout, in milliseconds, used when fetching variants triggered by calling start() or setUser().
+   */
+  fetchTimeoutMillis: number;
+
+  /**
+   * The number of retries to attempt if fetching variants triggered by start() or setUser() fails.
+   * // TODO: Implment background retries.
+   */
+  fetchRetries: number;
 }
 
 /**
@@ -78,4 +89,6 @@ export const Defaults: SkylabConfig = {
   preferInitialFlags: false,
   serverUrl: 'https://api.lab.amplitude.com',
   storageKey: 'amp-sl-meta',
+  fetchTimeoutMillis: 1000,
+  fetchRetries: 5,
 };

--- a/packages/browser/src/config.ts
+++ b/packages/browser/src/config.ts
@@ -105,7 +105,7 @@ export const Defaults: SkylabConfig = {
   preferInitialFlags: false,
   serverUrl: 'https://api.lab.amplitude.com',
   storageKey: 'amp-sl-meta',
-  fetchTimeoutMillis: 5000,
+  fetchTimeoutMillis: 10000,
   fetchRetry: true,
   fetchRetryTimeoutMillis: 10000,
   fetchRetryIntervalMillis: 10000,

--- a/packages/browser/src/config.ts
+++ b/packages/browser/src/config.ts
@@ -88,7 +88,7 @@ export interface SkylabConfig {
  | **preferInitialFlags**      | false                  |
  | **serverUrl**    | `"https://api.lab.amplitude.com"` |
  | **storageKey**    | `"amp-sl-meta"` |
- | **fetchTimeoutMillis**        | `500`                |
+ | **fetchTimeoutMillis**        | `5000`                |
  | **fetchRetry**                | `true`               |
  | **fetchRetryTimeoutMillis**   | `10000`              |
  | **fetchRetryIntervalMillis**  | `10000`              |

--- a/packages/browser/src/config.ts
+++ b/packages/browser/src/config.ts
@@ -58,13 +58,19 @@ export interface SkylabConfig {
 
   /**
    * Whether or not to retry fetching variants if the initial request fails. Retries will be scheduled at an
-   * interval defined by `fetchRetryIntervalMillis`.
+   * interval defined by `fetchRetryIntervalMillis`, with a timeout defined by `fetchRetryTimeoutMillis`.
    */
   fetchRetry: boolean;
 
   /**
-   * The interval at which to retry if the intitial variant fetch fails. This should be greater than
-   * `fetchTimeoutMillis`.
+   * The request timeout for retrying fetch requests. Should be less than or eqial to the
+   * `fetchRetryIntervalMillis` config.
+   */
+  fetchRetryTimeoutMillis: number;
+
+  /**
+   * The interval at which to retry if fetching variants fails. Should be greater than or equal to the
+   * `fetchRetryTimeoutMillis` config.
    */
   fetchRetryIntervalMillis: number;
 }
@@ -84,7 +90,8 @@ export interface SkylabConfig {
  | **storageKey**    | `"amp-sl-meta"` |
  | **fetchTimeoutMillis**        | `500`                |
  | **fetchRetry**                | `true`               |
- | **fetchRetryIntervalMillis**  | `5000`               |
+ | **fetchRetryTimeoutMillis**   | `10000`              |
+ | **fetchRetryIntervalMillis**  | `10000`              |
 
  *
  * @category Configuration
@@ -100,5 +107,6 @@ export const Defaults: SkylabConfig = {
   storageKey: 'amp-sl-meta',
   fetchTimeoutMillis: 500,
   fetchRetry: true,
-  fetchRetryIntervalMillis: 5000,
+  fetchRetryTimeoutMillis: 10000,
+  fetchRetryIntervalMillis: 10000,
 };

--- a/packages/browser/src/skylabClient.ts
+++ b/packages/browser/src/skylabClient.ts
@@ -35,7 +35,7 @@ export class SkylabClient implements Client {
   protected user: SkylabUser;
   protected contextProvider: ContextProvider;
 
-  private retries: any = null;
+  private retryHandle: any = null;
 
   /**
    * Creates a new SkylabClient instance.
@@ -225,7 +225,7 @@ export class SkylabClient implements Client {
       console.debug('[Skylab] Retry fetch all');
     }
     // Non-zero retry means we already have a retry interval in progress.
-    if (this.retries) {
+    if (this.retryHandle) {
       if (this.debug) {
         console.debug('[Skylab] Retry fetch interval already in progress');
       }
@@ -233,7 +233,7 @@ export class SkylabClient implements Client {
     }
     // Run fetchAll for the current user at an interval defined by the
     // fetchRetryIntervalMillis config.
-    this.retries = globalThis.setInterval(async () => {
+    this.retryHandle = globalThis.setInterval(async () => {
       try {
         await this.fetchAll(
           this.user,
@@ -248,8 +248,8 @@ export class SkylabClient implements Client {
   }
 
   protected stopRetries(): void {
-    globalThis.clearInterval(this.retries);
-    this.retries = null;
+    globalThis.clearInterval(this.retryHandle);
+    this.retryHandle = null;
   }
 
   private addContext(user: SkylabUser) {

--- a/packages/browser/src/skylabClient.ts
+++ b/packages/browser/src/skylabClient.ts
@@ -153,7 +153,6 @@ export class SkylabClient implements Client {
       this.storeVariants(variants);
       return variants;
     } catch (e) {
-      console.error(e);
       if (retry) {
         this.startRetries();
       }
@@ -241,6 +240,7 @@ export class SkylabClient implements Client {
           this.config.fetchRetryTimeoutMillis,
           false,
         );
+        this.stopRetries();
       } catch (e) {
         console.error(e);
       }

--- a/packages/browser/src/skylabClient.ts
+++ b/packages/browser/src/skylabClient.ts
@@ -107,6 +107,7 @@ export class SkylabClient implements Client {
   public async setUser(user: SkylabUser): Promise<SkylabClient> {
     this.user = user;
     try {
+      console.debug('user = ', user);
       await this.fetchAll(
         user,
         this.config.fetchTimeoutMillis,
@@ -176,6 +177,9 @@ export class SkylabClient implements Client {
     const headers = {
       Authorization: `Api-Key ${this.apiKey}`,
     };
+    if (this.debug) {
+      console.debug('[Skylab] Fetch variants for user: ', userContext);
+    }
     const response = await this.httpClient.requestWithTimeout(
       timeoutMillis,
       endpoint,

--- a/packages/browser/src/transport/http.ts
+++ b/packages/browser/src/transport/http.ts
@@ -27,7 +27,7 @@ const timeout = (
     }, timeoutMillis);
     promise.then(resolve, reject);
   });
-}
+};
 
 const request: HttpClient['request'] = (
   requestUrl: string,

--- a/packages/browser/src/transport/http.ts
+++ b/packages/browser/src/transport/http.ts
@@ -22,6 +22,26 @@ const request: HttpClient['request'] = (
   });
 };
 
+const requestWithTimeout: HttpClient['requestWithTimeout'] = (
+  timeoutMillis: number,
+  requestUrl: string,
+  method: string,
+  headers: Record<string, string>,
+  data?: Record<string, string>,
+): Promise<Response> => {
+  const controller = new AbortController();
+  const signal = controller.signal;
+  const timeout = window.setTimeout(() => controller.abort(), timeoutMillis);
+  const promise = fetch(requestUrl, {
+    method,
+    headers,
+    body: data && JSON.stringify(data),
+    signal,
+  });
+  return promise.finally(() => window.clearTimeout(timeout));
+};
+
 export const FetchHttpClient: HttpClient = {
   request,
+  requestWithTimeout,
 };

--- a/packages/browser/src/transport/http.ts
+++ b/packages/browser/src/transport/http.ts
@@ -13,10 +13,10 @@ const fetch = globalThis.fetch || unfetch;
  * Copied from:
  * https://github.com/github/fetch/issues/175#issuecomment-284787564
  */
-function timeout(
+const timeout = (
   promise: Promise<Response>,
   timeoutMillis?: number,
-): Promise<Response> {
+): Promise<Response> => {
   // Dont timeout if timeout is null or invalid
   if (timeoutMillis == null || timeoutMillis <= 0) {
     return promise;

--- a/packages/browser/src/types/transport.ts
+++ b/packages/browser/src/types/transport.ts
@@ -4,13 +4,6 @@ export interface HttpClient {
     method: string,
     headers: Record<string, string>,
     data?: Record<string, string>,
-  ): Promise<Response>;
-
-  requestWithTimeout(
-    timeoutMillis: number,
-    requestUrl: string,
-    method: string,
-    headers: Record<string, string>,
-    data?: Record<string, string>,
+    timeoutMillis?: number,
   ): Promise<Response>;
 }

--- a/packages/browser/src/types/transport.ts
+++ b/packages/browser/src/types/transport.ts
@@ -5,4 +5,12 @@ export interface HttpClient {
     headers: Record<string, string>,
     data?: Record<string, string>,
   ): Promise<Response>;
+
+  requestWithTimeout(
+    timeoutMillis: number,
+    requestUrl: string,
+    method: string,
+    headers: Record<string, string>,
+    data?: Record<string, string>,
+  ): Promise<Response>;
 }

--- a/packages/browser/src/util/backoff.ts
+++ b/packages/browser/src/util/backoff.ts
@@ -30,7 +30,6 @@ export class Backoff {
   }
 
   public cancel(): void {
-    console.debug('[Skylab] Cancel retries');
     this.done = true;
     clearTimeout(this.timeoutHandle);
   }
@@ -45,7 +44,6 @@ export class Backoff {
     }
     this.timeoutHandle = setTimeout(async () => {
       try {
-        console.debug('[Skylab] Retry attempt ', attempt);
         await fn();
       } catch (e) {
         const nextAttempt = attempt + 1;

--- a/packages/browser/src/util/backoff.ts
+++ b/packages/browser/src/util/backoff.ts
@@ -1,0 +1,65 @@
+export class Backoff {
+  private readonly attempts: number;
+  private readonly min: number;
+  private readonly max: number;
+  private readonly scalar: number;
+
+  private started = false;
+  private done = false;
+  private timeoutHandle: any;
+
+  public constructor(
+    attempts: number,
+    min: number,
+    max: number,
+    scalar: number,
+  ) {
+    this.attempts = attempts;
+    this.min = min;
+    this.max = max;
+    this.scalar = scalar;
+  }
+
+  public async start(fn: () => Promise<void>): Promise<void> {
+    if (!this.started) {
+      this.started = true;
+    } else {
+      throw Error('Backoff already started');
+    }
+    await this.backoff(fn, 0, this.min);
+  }
+
+  public cancel(): void {
+    console.debug('[Skylab] Cancel retries');
+    this.done = true;
+    clearTimeout(this.timeoutHandle);
+  }
+
+  private async backoff(
+    fn: () => Promise<void>,
+    attempt: number,
+    delay: number,
+  ): Promise<void> {
+    if (this.done) {
+      return;
+    }
+    this.timeoutHandle = setTimeout(async () => {
+      try {
+        console.debug('[Skylab] Retry attempt ', attempt);
+        await fn();
+      } catch (e) {
+        const nextAttempt = attempt + 1;
+        if (nextAttempt < this.attempts) {
+          console.error('[Skylab] Retry ' + attempt + ' failed: ', e);
+          const nextDelay = Math.min(delay * this.scalar, this.max);
+          this.backoff(fn, nextAttempt, nextDelay);
+        } else {
+          console.error(
+            '[Skylab] Retries failed after ' + this.attempts + ' attempts: ',
+            e,
+          );
+        }
+      }
+    }, delay);
+  }
+}

--- a/packages/browser/test/util/base64.test.ts
+++ b/packages/browser/test/util/base64.test.ts
@@ -1,4 +1,4 @@
-import { stringToUtf8Array, urlSafeBase64Encode } from 'src/util/base64';
+import { stringToUtf8Array, urlSafeBase64Encode } from '../../src/util/base64';
 
 test('stringToUtf8Array', () => {
   expect(stringToUtf8Array('My 🚀 is full of 🦎')).toEqual([


### PR DESCRIPTION
<!--
Thanks for contributing to the Amplitude Experiment Javascript Client SDK! 🎉

Please fill out the following sections to help us quickly review your pull request.
-->

### Summary

<!-- What does the PR do? -->

* Add 4 new config options for configuring fetch timeout and retries:
  - `fetchTimeoutMillis`: timeout for the initial fetch request. (default 500)
  - `fetchRetry`: boolean flag for disabling retries (default true)
  - `fetchRetryTimeoutMillis`: timeout for retry requests (default 10000)
  - `fetchRetryIntervalMillis`: interval for retrying fetch request (default 10000)
* `SkylabClient`'s protected methods have been refactored a bit in order to better support timeout & retries.
  - `fetchAll` as been broken up into `doFetch`, `parseResponse`, and `storeVariants` for better testability.
* Transport protocol has been updated with a `requestWithTimeout` method which uses an `AbortController` to cancel requests.

### Checklist

* [x] Does your PR title have the correct [title format](https://github.com/amplitude/skylab-js-client/blob/main/CONTRIBUTING.md#pr-commit-title-conventions)?
* Does your PR have a breaking change?:  <!-- Yes or no --> Yes
