### PR TITLE
fix: change globalThis to a browser/node/script tag-safe version

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "version": "0.1.1",
   "description": "Javascript Client SDK for Amplitude Skylab",
   "scripts": {
-    "build": "yarn workspace browser build",
+    "build": "yarn workspace @amplitude/skylab-js-client build",
     "lint": "lerna run lint",
     "test": "jest",
     "start": "yarn workspace browser-demo start"

--- a/packages/browser-demo/public/test-umd.html
+++ b/packages/browser-demo/public/test-umd.html
@@ -1,1 +1,9 @@
 <script src="../../browser/dist/skylab.umd.js"></script>
+<script>
+   const apiKey = "client-IAxMYws9vVQESrrK88aTcToyqMxiiJoR"; // This is provided in your Skylab product settings
+
+  var Skylab = Skylab.Skylab;
+  Skylab.init(apiKey);
+
+  Skylab.instance().start();
+</script>

--- a/packages/browser/rollup.config.js
+++ b/packages/browser/rollup.config.js
@@ -19,7 +19,7 @@ const browserConfig = {
   treeshake: {
     moduleSideEffects: 'no-external',
   },
-  external: ['http', 'https', 'querystring', 'url'],
+  external: [],
   plugins: [
     replace({ BUILD_BROWSER: true }),
     resolve(),

--- a/packages/browser/src/transport/http.ts
+++ b/packages/browser/src/transport/http.ts
@@ -6,8 +6,9 @@
 import unfetch from 'unfetch';
 
 import { HttpClient } from '../types/transport';
+import { safeGlobal } from '../util/global';
 
-const fetch = globalThis.fetch || unfetch;
+const fetch = safeGlobal.fetch || unfetch;
 
 /*
  * Copied from:
@@ -22,7 +23,7 @@ const timeout = (
     return promise;
   }
   return new Promise(function (resolve, reject) {
-    globalThis.setTimeout(function () {
+    safeGlobal.setTimeout(function () {
       reject(Error('Request timeout after ' + timeoutMillis + ' milliseconds'));
     }, timeoutMillis);
     promise.then(resolve, reject);

--- a/packages/browser/src/util/backoff.ts
+++ b/packages/browser/src/util/backoff.ts
@@ -1,4 +1,4 @@
-import { safeGlobal } from '../util/global';
+import { safeGlobal } from './global';
 
 export class Backoff {
   private readonly attempts: number;

--- a/packages/browser/src/util/backoff.ts
+++ b/packages/browser/src/util/backoff.ts
@@ -1,3 +1,5 @@
+import { safeGlobal } from '../util/global';
+
 export class Backoff {
   private readonly attempts: number;
   private readonly min: number;
@@ -42,7 +44,7 @@ export class Backoff {
     if (this.done) {
       return;
     }
-    this.timeoutHandle = setTimeout(async () => {
+    this.timeoutHandle = safeGlobal.setTimeout(async () => {
       try {
         await fn();
       } catch (e) {

--- a/packages/browser/src/util/global.ts
+++ b/packages/browser/src/util/global.ts
@@ -1,0 +1,4 @@
+type GlobalType = typeof globalThis | (NodeJS.Global & typeof globalThis);
+
+export const safeGlobal =
+  typeof globalThis !== 'undefined' ? globalThis : global || self;


### PR DESCRIPTION
<!--
Thanks for contributing to the Amplitude Experiment Javascript Client SDK! 🎉

Please fill out the following sections to help us quickly review your pull request.
-->

### Summary

<!-- What does the PR do? -->

This fixes issues that some browsers have with globalThis. We can't just use global because global is not defined when the script is loaded via <script> tags.

There is likely a better way to do this, or we may want to compile separate versions for loading via script tag vs compiled browser vs Node.

### Checklist

* [x] Does your PR title have the correct [title format](https://github.com/amplitude/skylab-js-client/blob/main/CONTRIBUTING.md#pr-commit-title-conventions)?
* Does your PR have a breaking change?:  <!-- Yes or no --> No
